### PR TITLE
Tor integration: TorDialer and OnionListener

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	tor "github.com/david415/oniondialer"
 	utp "github.com/jbenet/go-multiaddr-net/Godeps/_workspace/src/github.com/h2so5/utp"
 	ma "github.com/jbenet/go-multiaddr-net/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 )
@@ -96,6 +97,23 @@ func FromNetAddr(a net.Addr) (ma.Multiaddr, error) {
 			return nil, errIncorrectNetAddr
 		}
 		return FromIP(ac.IP)
+
+	case "onion":
+		onionAddr, ok := a.(*tor.OnionAddr)
+		if !ok {
+			return nil, errIncorrectNetAddr
+		}
+
+		fields := strings.Split(onionAddr.String(), ":")
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid onion addr doesn't contain a port %v", onionAddr)
+		}
+		// Get Tor Onion Addr
+		onionm, err := ma.NewMultiaddr(fmt.Sprintf("/onion/%s:%s", fields[0], fields[1]))
+		if err != nil {
+			return nil, errIncorrectNetAddr
+		}
+		return onionm, nil
 
 	default:
 		return nil, fmt.Errorf("unknown network %v", a.Network())

--- a/convert.go
+++ b/convert.go
@@ -3,6 +3,7 @@ package manet
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	tor "github.com/david415/oniondialer"
@@ -157,12 +158,22 @@ func FromIP(ip net.IP) (ma.Multiaddr, error) {
 
 // DialArgs is a convenience function returning arguments for use in net.Dial
 func DialArgs(m ma.Multiaddr) (string, string, error) {
-	if !IsThinWaist(m) {
-		return "", "", fmt.Errorf("%s is not a 'thin waist' address", m)
-	}
-
 	str := m.String()
 	parts := strings.Split(str, "/")[1:]
+
+	switch parts[0] {
+	case "onion":
+		addr := strings.Split(parts[1], ":")
+		if len(addr) != 2 {
+			return "", "", fmt.Errorf("failed to parse addr %s: does not contain a port number.", str)
+		}
+		onionHost := addr[0] + ".onion"
+		onionPort, err := strconv.Atoi(addr[1])
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse addr %s: invalid port number", str)
+		}
+		return "onion", fmt.Sprintf("%s:%s", onionHost, onionPort), nil
+	}
 
 	if len(parts) == 2 { // only IP
 		return parts[0], parts[1], nil


### PR DESCRIPTION

Dear Juan,

What do you think of these code changes so far?

Clearly it's mostly client side changes now... I haven't yet adjusted the Listener code much... because there are some open API design questions... In particular it seems that go-ipfs expects to create multiaddr-net Listener by simply giving it a multiaddr... however for the Tor OnionListener case we need to either already have onion key material or we need auto-create a new onion address. Either way we have a slight API impedance mismatch. How shall we solve this? I've also commented on it here:

https://github.com/ipfs/notes/issues/37#issuecomment-143433976
