### PR TITLE
add DialContext method and use DialContext from stdlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 sudo: false
 
 go:
-  - 1.5.3
+  - 1.7
 
 install:
   - make deps

--- a/multiaddr/multiaddr.go
+++ b/multiaddr/multiaddr.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	ma "github.com/jbenet/go-multiaddr"
-	manet "github.com/jbenet/go-multiaddr-net"
+	manet "github.com/multiformats/go-multiaddr-net"
 )
 
 // flags

--- a/net.go
+++ b/net.go
@@ -1,6 +1,7 @@
 package manet
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -86,7 +87,10 @@ type Dialer struct {
 // net.Conn, then wraps that in a Conn object (with local and
 // remote Multiaddrs).
 func (d *Dialer) Dial(remote ma.Multiaddr) (Conn, error) {
+	return d.DialContext(context.Background(), remote)
+}
 
+func (d *Dialer) DialContext(ctx context.Context, remote ma.Multiaddr) (Conn, error) {
 	// if a LocalAddr is specified, use it on the embedded dialer.
 	if d.LocalAddr != nil {
 		// convert our multiaddr to net.Addr friendly
@@ -109,7 +113,7 @@ func (d *Dialer) Dial(remote ma.Multiaddr) (Conn, error) {
 	var nconn net.Conn
 	switch rnet {
 	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
-		nconn, err = d.Dialer.Dial(rnet, rnaddr)
+		nconn, err = d.Dialer.DialContext(ctx, rnet, rnaddr)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This will allow us to cancel dials *much* more readily, and will severely reduce the file descriptor load on libp2p.

Note: This requires go1.7