### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multiaddr/net - Multiaddr friendly net
 
-Package multiaddr/net provides [Multiaddr](http://github.com/multiformats/go-multiaddr) specific versions of common
+Package multiaddr/net provides [Multiaddr](https://github.com/multiformats/go-multiaddr) specific versions of common
 functions in stdlib's net package. This means wrappers of
 standard net symbols like net.Dial and net.Listen, as well
 as conversion to/from net.Addr.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://github.com/multiformats/go-multiaddr | https://github.com/multiformats/go-multiaddr 
