### PR TITLE
Check for local ip6 addresses with more flexbility

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -63,7 +63,7 @@ func IsIPLoopback(m ma.Multiaddr) bool {
 	}
 
 	// /ip6/::1
-	if IP6Loopback.Equal(m) || IP6LinkLocalLoopback.Equal(m) {
+	if !m.Decapsulate(IP6Loopback).Equal(m) || !m.Decapsulate(IP6LinkLocalLoopback).Equal(m) {
 		return true
 	}
 


### PR DESCRIPTION
Currently IsIPLoopback returns true for any multiaddr starting ip4/127, but only returns true on ip6 addresses that exactly equal ip6/::1. So /ip6/::1/tcp/4001 for example does not return true. Instead we should check whether ip6/::1 is contained in the multiaddr, and to do that I simply decapsulated and checked to see if the result is different. It seems this was not caught by tests as none are present specifically for this function.