### PR TITLE
Make the IP loopback check faster

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -24,6 +24,14 @@ var (
 	IP6Unspecified = ma.StringCast("/ip6/::")
 )
 
+// Loopback multiaddr prefixes. Any multiaddr beginning with one of the
+// following byte sequences is considered a loopback multiaddr.
+var loopbackPrefixes = [][]byte{
+	{ma.P_IP4, 127}, // 127.*
+	IP6LinkLocalLoopback.Bytes(),
+	IP6Loopback.Bytes(),
+}
+
 // IsThinWaist returns whether a Multiaddr starts with "Thin Waist" Protocols.
 // This means: /{IP4, IP6}[/{TCP, UDP}]
 func IsThinWaist(m ma.Multiaddr) bool {
@@ -51,17 +59,11 @@ func IsThinWaist(m ma.Multiaddr) bool {
 	}
 }
 
-var localPrefixes = [][]byte{
-	{ma.P_IP4, 127}, // 127.*
-	IP6LinkLocalLoopback.Bytes(),
-	IP6Loopback.Bytes(),
-}
-
 // IsIPLoopback returns whether a Multiaddr is a "Loopback" IP address
 // This means either /ip4/127.*.*.*, /ip6/::1, or /ip6/fe80::1
 func IsIPLoopback(m ma.Multiaddr) bool {
 	b := m.Bytes()
-	for _, prefix := range localPrefixes {
+	for _, prefix := range loopbackPrefixes {
 		if bytes.HasPrefix(b, prefix) {
 			return true
 		}

--- a/ip.go
+++ b/ip.go
@@ -51,22 +51,21 @@ func IsThinWaist(m ma.Multiaddr) bool {
 	}
 }
 
+var localPrefixes = [][]byte{
+	{ma.P_IP4, 127}, // 127.*
+	IP6LinkLocalLoopback.Bytes(),
+	IP6Loopback.Bytes(),
+}
+
 // IsIPLoopback returns whether a Multiaddr is a "Loopback" IP address
-// This means either /ip4/127.0.0.1 or /ip6/::1
-// TODO: differentiate IsIPLoopback and OverIPLoopback
+// This means either /ip4/127.*.*.*, /ip6/::1, or /ip6/fe80::1
 func IsIPLoopback(m ma.Multiaddr) bool {
 	b := m.Bytes()
-
-	// /ip4/127 prefix (_entire_ /8 is loopback...)
-	if bytes.HasPrefix(b, []byte{ma.P_IP4, 127}) {
-		return true
+	for _, prefix := range localPrefixes {
+		if bytes.HasPrefix(b, prefix) {
+			return true
+		}
 	}
-
-	// /ip6/::1
-	if !m.Decapsulate(IP6Loopback).Equal(m) || !m.Decapsulate(IP6LinkLocalLoopback).Equal(m) {
-		return true
-	}
-
 	return false
 }
 

--- a/net_test.go
+++ b/net_test.go
@@ -314,6 +314,18 @@ func TestIPLoopback(t *testing.T) {
 		t.Error("IsIPLoopback failed (IP4Loopback)")
 	}
 
+	if !IsIPLoopback(newMultiaddr(t, "/ip4/127.1.80.9")) {
+		t.Error("IsIPLoopback failed (/ip4/127.1.80.9)")
+	}
+
+	if IsIPLoopback(newMultiaddr(t, "/ip4/112.123.11.1")) {
+		t.Error("IsIPLoopback false positive (/ip4/112.123.11.1)")
+	}
+
+	if IsIPLoopback(newMultiaddr(t, "/ip4/192.168.0.1/ip6/::1")) {
+		t.Error("IsIPLoopback false positive (/ip4/192.168.0.1/ip6/::1)")
+	}
+
 	if !IsIPLoopback(IP6Loopback) {
 		t.Error("IsIPLoopback failed (IP6Loopback)")
 	}


### PR DESCRIPTION
Decapsulate currently allocates a lot and this appears to have been causing some issues (hard to tell, pprof is misbehaving).

Note: I removed the TODO as this function now *only* checks if we're dealing with a loopback address. Not sure what `OverIPLoopback` was supposed to mean.

Note 2: Decapsulate actually checked if the IP6 loopback addresses appeared *anywhere* in the multiadder. However, as we weren't doing this for IP4, I decided to simplify this and only check prefixes.

This came up when profile the swarm refactor.