### PR TITLE
dialargs: perform multiaddr-dns lookup before thin waist

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -1,11 +1,13 @@
 package manet
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
 
 	ma "github.com/multiformats/go-multiaddr"
+	madns "github.com/multiformats/go-multiaddr-dns"
 )
 
 var errIncorrectNetAddr = fmt.Errorf("incorrect network addr conversion")
@@ -80,6 +82,13 @@ func FromIP(ip net.IP) (ma.Multiaddr, error) {
 
 // DialArgs is a convenience function returning arguments for use in net.Dial
 func DialArgs(m ma.Multiaddr) (string, string, error) {
+	if madns.Matches(m) {
+		resolvedMAddrs, err := madns.Resolve(context.TODO(), m)
+		if err != nil {
+			return "", "", err
+		}
+		m = resolvedMAddrs[0]
+	}
 	// TODO: find a 'good' way to eliminate the function.
 	// My preference is with a multiaddr.Format(...) function
 	if !IsThinWaist(m) {

--- a/convert_test.go
+++ b/convert_test.go
@@ -141,4 +141,7 @@ func TestDialArgs(t *testing.T) {
 	test("/ip4/127.0.0.1/tcp/4321", "tcp4", "127.0.0.1:4321")
 	test("/ip6/::1/udp/1234", "udp6", "[::1]:1234")
 	test("/ip6/::1/tcp/4321", "tcp6", "[::1]:4321")
+	// below tests rely on /etc/hosts containing default 'localhost' entries
+	test("/dns4/localhost/tcp/5001", "tcp4", "127.0.0.1:5001")
+	test("/dns6/localhost/tcp/5001", "tcp6", "[::1]:5001")
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
       "hash": "QmUxSEGbv2nmYNnfXi7839wwQqTN3kwQeUxe8dTjZWZs7J",
       "name": "go-multiaddr",
       "version": "1.2.7"
+    },
+    {
+      "author": "lgierth",
+      "hash": "QmT8461vVVyBPyHJHQ6mvm8UdQ8UZNA5n6Z7kBk7GRf1xu",
+      "name": "go-multiaddr-dns",
+      "version": "0.2.3"
     }
   ],
   "gxVersion": "0.6.0",


### PR DESCRIPTION
So we came across this issue in ipfs/ipfs-cluster#462 the other day, due to docker-compose but that is unrelated. 

I am not sure whether this is a viable solution in the context of the multiaddr/libp2p/ipfs ecosystem, but I thought I would see if I could implement and if it gets merged bonus 👍 

The other way I was thinking of doing was to create a `ResolveDialArgs` function that moves the dns resolving out into a wrapping function, that if people want to use they can, if also would allow for proper use of the `context` that is passed to `Resolve`.