### PR TITLE
fix IsIP* functions

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -1,7 +1,7 @@
 package manet
 
 import (
-	"bytes"
+	"net"
 
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -23,14 +23,6 @@ var (
 	IP4Unspecified = ma.StringCast("/ip4/0.0.0.0")
 	IP6Unspecified = ma.StringCast("/ip6/::")
 )
-
-// Loopback multiaddr prefixes. Any multiaddr beginning with one of the
-// following byte sequences is considered a loopback multiaddr.
-var loopbackPrefixes = [][]byte{
-	{ma.P_IP4, 127}, // 127.*
-	{ma.P_IP6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 127}, // ::ffff:127.*
-	IP6Loopback.Bytes(), // ::1
-}
 
 // IsThinWaist returns whether a Multiaddr starts with "Thin Waist" Protocols.
 // This means: /{IP4, IP6}[/{TCP, UDP}]
@@ -63,21 +55,30 @@ func IsThinWaist(m ma.Multiaddr) bool {
 // This means either /ip4/127.*.*.*, /ip6/::1, or /ip6/::ffff:127.*.*.*.*
 func IsIPLoopback(m ma.Multiaddr) bool {
 	b := m.Bytes()
-	for _, prefix := range loopbackPrefixes {
-		if bytes.HasPrefix(b, prefix) {
-			return true
+	switch len(b) {
+	case net.IPv4len + 1:
+		if b[0] != ma.P_IP4 {
+			return false
 		}
+	case net.IPv6len + 1:
+		if b[0] != ma.P_IP6 {
+			return false
+		}
+	default:
+		return false
 	}
-	return false
+	return net.IP(b[1:]).IsLoopback()
 }
 
 // IsIP6LinkLocal returns if a multiaddress is an IPv6 local link. These
-// addresses are non routable. The prefix is technically
-// fe80::/10, but we test fe80::/16 for simplicity (no need to mask).
-// So far, no hardware interfaces exist long enough to use those 2 bits.
-// Send a PR if there is.
+// addresses are non routable.
 func IsIP6LinkLocal(m ma.Multiaddr) bool {
-	return bytes.HasPrefix(m.Bytes(), []byte{ma.P_IP6, 0xfe, 0x80})
+	b := m.Bytes()
+	if len(b) != (1+net.IPv6len) || b[0] != ma.P_IP6 {
+		return false
+	}
+	ip := net.IP(b[1:])
+	return ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast()
 }
 
 // IsIPUnspecified returns whether a Multiaddr is am Unspecified IP address

--- a/net_test.go
+++ b/net_test.go
@@ -363,7 +363,7 @@ func TestIPUnspecified(t *testing.T) {
 
 func TestIP6LinkLocal(t *testing.T) {
 	for a := 0; a < 65536; a++ {
-		isLinkLocal := (a == 0xfe80)
+		isLinkLocal := (a&0xffc0 == 0xfe80 || a&0xff0f == 0xff02)
 		m := newMultiaddr(t, fmt.Sprintf("/ip6/%x::1", a))
 		if IsIP6LinkLocal(m) != isLinkLocal {
 			t.Errorf("IsIP6LinkLocal failed (%s != %v)", m, isLinkLocal)

--- a/net_test.go
+++ b/net_test.go
@@ -306,7 +306,7 @@ func TestIPLoopback(t *testing.T) {
 		t.Error("IP6Loopback incorrect:", IP6Loopback)
 	}
 
-	if IP4MappedIP6Loopback.String() != "/ip6/127.0.0.1" {
+	if IP4MappedIP6Loopback.String() != "/ip6/::ffff:127.0.0.1" {
 		t.Error("IP4MappedIP6Loopback incorrect:", IP4MappedIP6Loopback)
 	}
 
@@ -330,12 +330,12 @@ func TestIPLoopback(t *testing.T) {
 		t.Error("IsIPLoopback failed (IP6Loopback)")
 	}
 
-	if !IsIPLoopback(newMultiaddr(t, "/ip6/127.0.0.1")) {
-		t.Error("IsIPLoopback failed (/ip6/127.0.0.1)")
+	if !IsIPLoopback(newMultiaddr(t, "/ip6/::ffff:127.0.0.1")) {
+		t.Error("IsIPLoopback failed (/ip6/::ffff:127.0.0.1)")
 	}
 
-	if !IsIPLoopback(newMultiaddr(t, "/ip6/127.99.3.2")) {
-		t.Error("IsIPLoopback failed (/ip6/127.99.3.2)")
+	if !IsIPLoopback(newMultiaddr(t, "/ip6/::ffff:127.99.3.2")) {
+		t.Error("IsIPLoopback failed (/ip6/::ffff:127.99.3.2)")
 	}
 
 	if IsIPLoopback(newMultiaddr(t, "/ip6/::fffa:127.99.3.2")) {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "multiformats",
-      "hash": "QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7",
+      "hash": "QmYeyfA6eWTAAWrqnnJ5Gud2MNiXPzVdvamCjiRQLQWEw5",
       "name": "go-multiaddr",
-      "version": "1.3.0"
+      "version": "1.3.2"
     }
   ],
   "gxVersion": "0.6.0",


### PR DESCRIPTION
1. Don't accept *prefixes*.
2. Use go's tests so we don't have to implement them.
3. Correctly detect *all* link-local addresses

Question: Should we drop 1 and fix the documentation?