### PR TITLE
make the Is* commands only check if addrs start with

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -55,17 +55,13 @@ func IsThinWaist(m ma.Multiaddr) bool {
 	}
 }
 
-// IsIPLoopback returns whether a Multiaddr is a "Loopback" IP address
-// This means either /ip4/127.*.*.*, /ip6/::1, or /ip6/::ffff:127.*.*.*.*,
-// or /ip6zone/<any value>/ip6/<one of the preceding ip6 values>
+// IsIPLoopback returns whether a Multiaddr starts with a "Loopback" IP address
+// This means either /ip4/127.*.*.*/*, /ip6/::1/*, or /ip6/::ffff:127.*.*.*.*/*,
+// or /ip6zone/<any value>/ip6/<one of the preceding ip6 values>/*
 func IsIPLoopback(m ma.Multiaddr) bool {
 	m = zoneless(m)
-	c, rest := ma.SplitFirst(m)
+	c, _ := ma.SplitFirst(m)
 	if c == nil {
-		return false
-	}
-	if rest != nil {
-		// Not *just* an IPv4 addr
 		return false
 	}
 	switch c.Protocol().Code {
@@ -88,14 +84,15 @@ func IsIP6LinkLocal(m ma.Multiaddr) bool {
 	return ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast()
 }
 
-// IsIPUnspecified returns whether a Multiaddr is am Unspecified IP address
-// This means either /ip4/0.0.0.0 or /ip6/::
+// IsIPUnspecified returns whether a Multiaddr starts with an Unspecified IP address
+// This means either /ip4/0.0.0.0/* or /ip6/::/*
 func IsIPUnspecified(m ma.Multiaddr) bool {
 	m = zoneless(m)
 	if m == nil {
 		return false
 	}
-	return IP4Unspecified.Equal(m) || IP6Unspecified.Equal(m)
+	c, _ := ma.SplitFirst(m)
+	return net.IP(c.RawValue()).IsUnspecified()
 }
 
 // If m matches [zone,ip6,...], return [ip6,...]

--- a/net_test.go
+++ b/net_test.go
@@ -330,10 +330,6 @@ func TestIPLoopback(t *testing.T) {
 		t.Error("IsIPLoopback false positive (/ip4/112.123.11.1)")
 	}
 
-	if IsIPLoopback(newMultiaddr(t, "/ip4/127.0.0.1/ip4/127.0.0.1")) {
-		t.Error("IsIPLoopback false positive (/ip4/127.0.0.1/127.0.0.1)")
-	}
-
 	if IsIPLoopback(newMultiaddr(t, "/ip4/192.168.0.1/ip6/::1")) {
 		t.Error("IsIPLoopback false positive (/ip4/192.168.0.1/ip6/::1)")
 	}
@@ -360,10 +356,6 @@ func TestIPLoopback(t *testing.T) {
 
 	if !IsIPLoopback(newMultiaddr(t, "/ip6zone/xxx/ip6/::1")) {
 		t.Error("IsIPLoopback failed (/ip6zone/xxx/ip6/::1)")
-	}
-
-	if IsIPLoopback(newMultiaddr(t, "/ip6zone/0/ip6/::1/tcp/3333")) {
-		t.Error("IsIPLoopback failed (/ip6zone/0/ip6/::1/tcp/3333)")
 	}
 
 	if IsIPLoopback(newMultiaddr(t, "/ip6zone/0/ip6/1::1")) {


### PR DESCRIPTION
It turns out we *were* relying on this. Furthermore, this is generally more useful (especially given ip6zones).