### PR TITLE
Feat: support hostnames in DialArgs() function

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -96,7 +96,7 @@ func FromIP(ip net.IP) (ma.Multiaddr, error) {
 
 // DialArgs is a convenience function that returns network and address as
 // expected by net.Dial. See https://godoc.org/net#Dial for an overview of
-// possible return values.
+// possible return values (we do not support the unix* ones yet).
 func DialArgs(m ma.Multiaddr) (string, string, error) {
 	var (
 		zone, network, ip, port string

--- a/convert_test.go
+++ b/convert_test.go
@@ -168,4 +168,8 @@ func TestDialArgs(t *testing.T) {
 	test_error("/ip6zone/foo/ip4/127.0.0.1")                        // IP4 doesn't take zone
 	test("/ip6zone/foo/ip6/::1/ip6zone/bar", "ip6", "::1%foo")      // IP over IP
 	test_error("/ip6zone/foo/ip6zone/bar/ip6/::1")                  // Only one zone per IP6
+	test("/dns4/abc.com/tcp/1234", "tcp4", "abc.com:1234")          // DNS4:port
+	test("/dns4/abc.com", "ip4", "abc.com")                         // Just DNS4
+	test("/dns6/abc.com/udp/1234", "udp6", "abc.com:1234")          // DNS6:port
+	test("/dns6/abc.com", "ip6", "abc.com")                         // Just DNS6
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
       "hash": "QmRKLtwMw131aK7ugC3G7ybpumMz78YrJe5dzneyindvG1",
       "name": "go-multiaddr",
       "version": "1.3.6"
+    },
+    {
+      "author": "lgierth",
+      "hash": "QmT4zgnKCyZBpRyxzsvZqUjzUkMWLJ2pZCw7uk6M6Kto5m",
+      "name": "go-multiaddr-dns",
+      "version": "0.2.6"
     }
   ],
   "gxVersion": "0.6.0",


### PR DESCRIPTION
I have some code in Cluster that uses `DialArgs` and it's really annoying that it only works with /ip*/ multiaddresses, and that in the case of dns multiaddresses, I need to extract hostnames manually if I want to make a standard net.http request using those hostnames.

I had forgotten we had #41 by the way. But if `net.Dial` etc are able to resolve hostnames, it should be just fine that we don't do it? In any case this approach was suggested by @Stebalien on that PR.

If doing this has many deep implications, I can always get around it, but it would be nice to have it here.

cc @lanzafame